### PR TITLE
Use newer APIs to launch applications to fix issue #38

### DIFF
--- a/Thor/ShortcutMonitor.swift
+++ b/Thor/ShortcutMonitor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Cocoa
 import MASShortcut
 
 struct ShortcutMonitor {
@@ -22,7 +23,18 @@ struct ShortcutMonitor {
                     frontmostAppIdentifier == targetAppIdentifier {
                     NSRunningApplication.runningApplications(withBundleIdentifier: frontmostAppIdentifier).first?.hide()
                 } else {
-                    NSWorkspace.shared.launchApplication(app.appName)
+                    if #available(macOS 10.15, *) {
+                        let configuration = NSWorkspace.OpenConfiguration()
+                        configuration.activates = true
+                        NSWorkspace.shared.openApplication(at: app.appBundleURL,
+                                                           configuration: configuration) { _, error in
+                            if let error = error {
+                                NSLog("ERROR: \(error)")
+                            }
+                        }
+                    } else {
+                        NSWorkspace.shared.launchApplication(app.appName)
+                    }
                 }
             })
         }


### PR DESCRIPTION
I use Cocoa [NSWorkspace openApplication](https://developer.apple.com/documentation/appkit/nsworkspace/3172700-openapplication) APIs as [launchApplication](https://developer.apple.com/documentation/appkit/nsworkspace/1531434-launchapplication/) is deprecated, and it fix the issue https://github.com/gbammc/Thor/issues/38