### PR TITLE
fix: sort keys before converting to JSON to make ordering consistent

### DIFF
--- a/Thor/AppsManager.swift
+++ b/Thor/AppsManager.swift
@@ -107,7 +107,7 @@ class AppsManager: NSObject {
     func saveData(to path: String) -> Bool {
         do {
             let apps = selectedApps.map { $0.encodeToJSONValue() }
-            let encoded = try JSONSerialization.data(withJSONObject: apps, options: [.prettyPrinted])
+            let encoded = try JSONSerialization.data(withJSONObject: apps, options: [.prettyPrinted, .sortedKeys])
             try encoded.write(to: URL(fileURLWithPath: path), options: [.atomic])
             return true
         } catch {


### PR DESCRIPTION
This change makes the generated JSON file from "Export Shortcuts" consistent.

Before the change, key (`appBundleURL`, `appDisplayName` and `shortcut`) ordering is random, which is annoying when the file is tracked via git.

The change should work for macOS 10.13+ as per doc https://developer.apple.com/documentation/foundation/jsonserialization/writingoptions/2888322-sortedkeys