### PR TITLE
fix: support key Return in exported config file

### DIFF
--- a/Thor/AppModel.swift
+++ b/Thor/AppModel.swift
@@ -170,6 +170,7 @@ extension MASShortcut {
         kVK_ANSI_Keypad8: "numpad8",
         kVK_ANSI_Keypad9: "numpad9",
 
+        kVK_Return: "return",
         kVK_End: "end",
         kVK_Home: "home",
         kVK_Tab: "tab",


### PR DESCRIPTION
The "Return" key is currently supported by Thor Launcher, but the config won't persist across app reboot, nor the shortcut saves to exported config file (the `shortcut` field would be empty).

This change fixes the issue.