### PR TITLE
Fix build on Xcode 14 and 15

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,3 +8,10 @@ target 'Thor' do
   pod 'Sparkle'
 end
 
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings.delete 'MACOSX_DEPLOYMENT_TARGET'
+    end
+  end
+end


### PR DESCRIPTION
Fix the following error:

Build target MASShortcut of project Pods with configuration Release Thor/Pods/Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.3.99. (in target 'MASShortcut' from project 'Pods')

---

Reference:
* https://stackoverflow.com/questions/37160688/set-deployment-target-for-cocoapodss-pod