### PR TITLE
feat: allow configuring enablement of shortcut to toggle thor in the menu bar

### DIFF
--- a/Thor/AppDelegate.swift
+++ b/Thor/AppDelegate.swift
@@ -32,7 +32,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DefaultsKeys.DeactivateKey.key: 0,
             DefaultsKeys.DelayInterval.key: 0.3,
             DefaultsKeys.EnableShortcut.key: true,
-            DefaultsKeys.enableMenuBarIcon.key: true
+            DefaultsKeys.enableMenuBarIcon.key: true,
+            DefaultsKeys.enableMenuBarIconShowHideKey.key: true
             ])
 
         NSApp.setActivationPolicy(.accessory)
@@ -43,8 +44,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             sharedAppDelegate?.statusItemController.hideInMenuBar()
         }
 
+        if defaults[.enableMenuBarIconShowHideKey] {
+            registerMenubarIconShortcut()
+        }
+
         shortcutEnableMonitor()
-        registerMenubarIconShortcut()
 
         if defaults.object(forKey: DefaultsKeys.LaunchAtLoginKey.key) != nil {
             defaults.removeObject(forKey: DefaultsKeys.LaunchAtLoginKey.key)
@@ -159,6 +163,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             NotificationCenter.default.post(name: .updateMenuBarToggleState, object: nil)
         })
+    }
+
+    func unregisterMenubarIconShortcut() {
+        let modifierFlags = NSEvent.ModifierFlags.shift.rawValue |
+            NSEvent.ModifierFlags.control.rawValue |
+            NSEvent.ModifierFlags.option.rawValue |
+            NSEvent.ModifierFlags.command.rawValue
+        let shortcut = MASShortcut(keyCode: kVK_ANSI_T, modifierFlags: NSEvent.ModifierFlags(rawValue: modifierFlags))
+        MASShortcutMonitor.shared().unregisterShortcut(shortcut)
     }
 
 }

--- a/Thor/Base.lproj/Main.storyboard
+++ b/Thor/Base.lproj/Main.storyboard
@@ -349,7 +349,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="Dtr-0d-C8U">
-                                <rect key="frame" x="45" y="196" width="104" height="16"/>
+                                <rect key="frame" x="45" y="154" width="104" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Reactivate after:" id="1fT-Qh-dE2">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -357,7 +357,7 @@
                                 </textFieldCell>
                             </textField>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ySw-Wg-Pgf">
-                                <rect key="frame" x="151" y="188" width="172" height="29"/>
+                                <rect key="frame" x="151" y="146" width="172" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="HaR-z1-X7a"/>
                                 </constraints>
@@ -391,7 +391,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cIc-ga-45L">
-                                <rect key="frame" x="45" y="232" width="99" height="16"/>
+                                <rect key="frame" x="45" y="190" width="99" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Deactivate Key:" id="uWp-Ys-dhU">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -399,7 +399,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hWC-9z-cv3">
-                                <rect key="frame" x="151" y="177" width="32" height="16"/>
+                                <rect key="frame" x="151" y="135" width="32" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0.1s" id="RmK-si-Zsx">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -407,7 +407,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9pw-DH-pgZ">
-                                <rect key="frame" x="302" y="175" width="21" height="16"/>
+                                <rect key="frame" x="302" y="133" width="21" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1s" id="UpG-OL-d8P">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -415,7 +415,7 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0zk-yi-rDJ" userLabel="⌘ Command Key">
-                                <rect key="frame" x="145" y="225" width="173" height="25"/>
+                                <rect key="frame" x="145" y="183" width="173" height="25"/>
                                 <popUpButtonCell key="cell" type="push" title="⇧ Shift Key" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="qJu-sX-5Pd" id="2rr-yT-VNc" userLabel="⌃ Control Key">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="menu"/>
@@ -440,7 +440,7 @@
                                 </connections>
                             </popUpButton>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="ych-hK-1qT">
-                                <rect key="frame" x="45" y="266" width="293" height="18"/>
+                                <rect key="frame" x="45" y="224" width="293" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable double tap to deactivate shortcuts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ntn-c3-HAA">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" size="13" name="STHeitiSC-Light"/>
@@ -462,14 +462,20 @@
                                     <action selector="toggleEnableMenuBarIcon:" target="LfM-H7-njo" id="QqI-Ja-rEW"/>
                                 </connections>
                             </button>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Vef-kW-xPq">
-                                <rect key="frame" x="64" y="317" width="284" height="13"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="⇧⌃⌥ ⌘ + T to show/hide" id="Qub-BS-LhT">
-                                    <font key="font" metaFont="system" size="10"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Lcx-bw-woE" userLabel="Btn Enable Menu Bar Icon Show/Hide Key">
+                                <rect key="frame" x="45" y="273" width="292" height="32"/>
+                                <buttonCell key="cell" type="check" title="Enable ⇧⌃⌥ ⌘ + T to show/hide Thor in the menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kOR-Gg-12E" userLabel="Enable ⇧⌃⌥ ⌘ + T to show/hide Thor in the menu bar">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" size="13" name="STHeitiSC-Light"/>
+                                </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="290" id="IPY-Ir-dXy"/>
+                                    <constraint firstAttribute="height" constant="28" id="JHI-wJ-c39"/>
+                                </constraints>
+                                <connections>
+                                    <action selector="toggleEnableMenuBarIconShowHideKey:" target="LfM-H7-njo" id="jTf-bs-bOM"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="0zk-yi-rDJ" secondAttribute="trailing" constant="52" id="0pu-kB-MFi"/>
@@ -477,7 +483,6 @@
                             <constraint firstItem="prA-Il-0qM" firstAttribute="leading" secondItem="Crp-4s-mEo" secondAttribute="leading" constant="90" id="1Tx-pu-Mto"/>
                             <constraint firstItem="9pw-DH-pgZ" firstAttribute="top" secondItem="ySw-Wg-Pgf" secondAttribute="bottom" constant="3" id="1r2-IW-hCj"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="d3U-w9-jNg" secondAttribute="trailing" constant="20" symbolic="YES" id="7A4-et-3p2"/>
-                            <constraint firstItem="ych-hK-1qT" firstAttribute="top" secondItem="Vef-kW-xPq" secondAttribute="bottom" constant="35" id="8ZZ-l5-KHr"/>
                             <constraint firstItem="XJy-eX-prE" firstAttribute="leading" secondItem="7sy-3X-TvI" secondAttribute="leading" id="8yE-nG-3YR"/>
                             <constraint firstItem="cIc-ga-45L" firstAttribute="leading" secondItem="Dtr-0d-C8U" secondAttribute="leading" id="ABh-Kh-94o"/>
                             <constraint firstItem="prA-Il-0qM" firstAttribute="centerX" secondItem="Crp-4s-mEo" secondAttribute="centerX" id="Afz-rC-qYb"/>
@@ -490,28 +495,28 @@
                             <constraint firstItem="d3U-w9-jNg" firstAttribute="leading" secondItem="7sy-3X-TvI" secondAttribute="leading" id="PAh-Wm-2kA"/>
                             <constraint firstItem="hWC-9z-cv3" firstAttribute="top" secondItem="ySw-Wg-Pgf" secondAttribute="bottom" constant="1" id="R7Z-q7-uy1"/>
                             <constraint firstItem="XJy-eX-prE" firstAttribute="leading" secondItem="Crp-4s-mEo" secondAttribute="leading" constant="47" id="TPK-B1-dpv"/>
-                            <constraint firstItem="Vef-kW-xPq" firstAttribute="leading" secondItem="Crp-4s-mEo" secondAttribute="leading" constant="66" id="WkL-KG-Bwd"/>
+                            <constraint firstItem="Lcx-bw-woE" firstAttribute="top" secondItem="d3U-w9-jNg" secondAttribute="bottom" constant="35" id="YWI-qf-QpZ"/>
                             <constraint firstItem="d3U-w9-jNg" firstAttribute="top" secondItem="7sy-3X-TvI" secondAttribute="bottom" constant="35" id="Yns-4x-PP5"/>
                             <constraint firstItem="7sy-3X-TvI" firstAttribute="leading" secondItem="ych-hK-1qT" secondAttribute="leading" id="dgY-s3-y2Y"/>
+                            <constraint firstItem="ych-hK-1qT" firstAttribute="top" secondItem="Lcx-bw-woE" secondAttribute="bottom" constant="35" id="dt7-ok-vmd"/>
                             <constraint firstItem="cIc-ga-45L" firstAttribute="top" secondItem="ych-hK-1qT" secondAttribute="bottom" constant="20" id="e9X-KM-xgc"/>
                             <constraint firstAttribute="trailing" secondItem="ych-hK-1qT" secondAttribute="trailing" constant="28" id="flW-eQ-HBq"/>
                             <constraint firstItem="7sy-3X-TvI" firstAttribute="top" secondItem="XJy-eX-prE" secondAttribute="bottom" constant="35" id="iev-sH-BcC"/>
                             <constraint firstItem="9pw-DH-pgZ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hWC-9z-cv3" secondAttribute="trailing" constant="8" symbolic="YES" id="j2v-d2-eIh"/>
                             <constraint firstItem="cIc-ga-45L" firstAttribute="baseline" secondItem="0zk-yi-rDJ" secondAttribute="firstBaseline" id="jQT-Gj-nXr"/>
-                            <constraint firstItem="Vef-kW-xPq" firstAttribute="top" secondItem="d3U-w9-jNg" secondAttribute="bottom" constant="8" symbolic="YES" id="lqv-8d-x7g"/>
                             <constraint firstItem="0zk-yi-rDJ" firstAttribute="baseline" secondItem="cIc-ga-45L" secondAttribute="firstBaseline" id="naB-jx-Dpc"/>
                             <constraint firstItem="ych-hK-1qT" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cIc-ga-45L" secondAttribute="leading" id="okT-QH-OjF"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7sy-3X-TvI" secondAttribute="trailing" constant="20" symbolic="YES" id="pAl-Ix-jpG"/>
-                            <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Vef-kW-xPq" secondAttribute="trailing" constant="20" symbolic="YES" id="s4S-7P-Rds"/>
+                            <constraint firstItem="Lcx-bw-woE" firstAttribute="leading" secondItem="Crp-4s-mEo" secondAttribute="leading" constant="47" id="sle-yJ-9aF"/>
                             <constraint firstAttribute="bottom" secondItem="prA-Il-0qM" secondAttribute="bottom" constant="20" symbolic="YES" id="taQ-Tf-jfr"/>
                             <constraint firstItem="ySw-Wg-Pgf" firstAttribute="trailing" secondItem="9pw-DH-pgZ" secondAttribute="trailing" id="uVo-Rg-JBi"/>
                             <constraint firstItem="0zk-yi-rDJ" firstAttribute="leading" secondItem="cIc-ga-45L" secondAttribute="trailing" constant="6" id="vtd-KI-5AV"/>
-                            <constraint firstItem="Vef-kW-xPq" firstAttribute="top" secondItem="d3U-w9-jNg" secondAttribute="bottom" constant="8" symbolic="YES" id="w8y-Kq-8aF"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="btnEnableDeactivateKey" destination="ych-hK-1qT" id="wjv-C6-I04"/>
                         <outlet property="btnEnableMenuBarIcon" destination="d3U-w9-jNg" id="VhB-4g-cwa"/>
+                        <outlet property="btnEnableMenuBarIconShowHideKey" destination="Lcx-bw-woE" id="ZxA-zv-c8A"/>
                         <outlet property="btnEnableShortcut" destination="7sy-3X-TvI" id="qGM-kS-fk6"/>
                         <outlet property="btnLaunchAtLogin" destination="XJy-eX-prE" id="xKD-J0-ALg"/>
                         <outlet property="btnShortcutDeactivateKey" destination="0zk-yi-rDJ" id="OzF-KE-TX0"/>

--- a/Thor/DefaultsKeys+Extension.swift
+++ b/Thor/DefaultsKeys+Extension.swift
@@ -18,5 +18,6 @@ extension DefaultsKeys {
     static let EnableDeactivateKey = DefaultsKey<Bool>("EnableDeactivateKey")
     static let LaunchAtLoginKey = DefaultsKey<Bool>("LaunchAtLoginKey")
     static let enableMenuBarIcon = DefaultsKey<Bool>("enableMenuBarIcon")
+    static let enableMenuBarIconShowHideKey = DefaultsKey<Bool>("enableMenuBarIconShowHideKey")
 
 }

--- a/Thor/SettingsViewController.swift
+++ b/Thor/SettingsViewController.swift
@@ -14,6 +14,7 @@ class SettingsViewController: NSViewController {
     @IBOutlet weak var btnLaunchAtLogin: NSButton!
     @IBOutlet weak var btnEnableShortcut: NSButton!
     @IBOutlet weak var btnEnableMenuBarIcon: NSButton!
+    @IBOutlet weak var btnEnableMenuBarIconShowHideKey: NSButton!
     @IBOutlet weak var btnEnableDeactivateKey: NSButton!
     @IBOutlet weak var btnShortcutDeactivateKey: NSPopUpButton!
     @IBOutlet weak var slider: NSSlider!
@@ -28,6 +29,7 @@ class SettingsViewController: NSViewController {
         btnEnableShortcut.state = defaults[.EnableShortcut] ? .on : .off
 
         btnEnableMenuBarIcon.state = defaults[.enableMenuBarIcon] ? .on : .off
+        btnEnableMenuBarIconShowHideKey.state = defaults[.enableMenuBarIconShowHideKey] ? .on : .off
 
         let isEnableDeactivateKey = defaults[.EnableDeactivateKey]
 
@@ -70,6 +72,18 @@ class SettingsViewController: NSViewController {
             sharedAppDelegate?.statusItemController.showInMenuBar()
         } else {
             sharedAppDelegate?.statusItemController.hideInMenuBar()
+        }
+    }
+
+    @IBAction func toggleEnableMenuBarIconShowHideKey(_ sender: Any) {
+        let enable = btnEnableMenuBarIconShowHideKey.state == .on
+
+        defaults[.enableMenuBarIconShowHideKey] = enable
+
+        if enable {
+            sharedAppDelegate?.registerMenubarIconShortcut()
+        } else {
+            sharedAppDelegate?.unregisterMenubarIconShortcut()
         }
     }
 

--- a/Thor/en.lproj/Main.strings
+++ b/Thor/en.lproj/Main.strings
@@ -47,9 +47,6 @@
 /* Class = "NSMenuItem"; title = "Import Shortcuts"; ObjectID = "QQw-cp-cqP"; */
 "QQw-cp-cqP.title" = "Import Shortcuts";
 
-/* Class = "NSTextFieldCell"; title = "⇧⌃⌥ ⌘ + T to show/hide"; ObjectID = "Qub-BS-LhT"; */
-"Qub-BS-LhT.title" = "⇧⌃⌥ ⌘ + T to show/hide";
-
 /* Class = "NSTextFieldCell"; title = "0.1s"; ObjectID = "RmK-si-Zsx"; */
 "RmK-si-Zsx.title" = "0.1s";
 
@@ -73,6 +70,9 @@
 
 /* Class = "NSButtonCell"; title = "Enable shortcut"; ObjectID = "fya-Hu-agS"; */
 "fya-Hu-agS.title" = "Enable shortcut";
+
+/* Class = "NSButtonCell"; title = "Enable ⇧⌃⌥ ⌘ + T to show/hide Thor in the menu bar"; ObjectID = "kOR-Gg-12E"; */
+"kOR-Gg-12E.title" = "Enable ⇧⌃⌥ ⌘ + T to show/hide Thor in the menu bar";
 
 /* Class = "NSMenuItem"; title = "⌥ Option Key"; ObjectID = "ltM-LE-FOy"; */
 "ltM-LE-FOy.title" = "⌥ Option Key";

--- a/Thor/zh-Hans.lproj/Main.strings
+++ b/Thor/zh-Hans.lproj/Main.strings
@@ -107,5 +107,5 @@
 /* Class = "NSMenuItem"; title = "Show Thor in the menu bar"; ObjectID = "LbD-19-0Ga"; */
 "LbD-19-0Ga.title" = "在状态栏显示 Thor 图标";
 
-/* Class = "NSTextFieldCell"; title = "⇧⌃⌥ ⌘ + T to show/hide"; ObjectID = "Qub-BS-LhT"; */
-"Qub-BS-LhT.title" = "⇧⌃⌥ ⌘ + T 显示/隐藏";
+/* Class = "NSButtonCell"; title = "Enable ⇧⌃⌥ ⌘ + T to show/hide Thor in the menu bar"; ObjectID = "kOR-Gg-12E"; */
+"kOR-Gg-12E.title" = "启用 ⇧⌃⌥ ⌘ + T 在状态栏切换显示/隐藏 Thor 图标";


### PR DESCRIPTION
Fixes #47 

This PR intends to give user a choice to use or not to use **⇧⌃⌥ ⌘ + T** to show/hide Thor in the menu bar.
This change can free up **⇧⌃⌥ ⌘ + T** for those want to bind it to an app while keeping the default the same as before.

Settings view is updated to expose this option:

Before | After
--- | ---
<img width="472" alt="Screenshot 2024-04-19 at 18 11 35" src="https://github.com/gbammc/Thor/assets/2920525/35e376bd-3e14-4476-ae01-939794622559"> | <img width="472" alt="Screenshot 2024-04-15 at 21 35 35" src="https://github.com/gbammc/Thor/assets/2920525/340759fd-ed24-4c05-82da-3e5b7407d67e">
<img width="472" alt="Screenshot 2024-04-19 at 18 12 19" src="https://github.com/gbammc/Thor/assets/2920525/ee75e936-00a9-47aa-956d-58f3d83c9fd8"> | <img width="472" alt="Screenshot 2024-04-15 at 21 34 36" src="https://github.com/gbammc/Thor/assets/2920525/cbca0028-caf9-40b4-8684-ddb6f8946da5">

